### PR TITLE
Post install script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,8 @@
 
     "scripts": {
         "post-install-cmd": [
-            "mkdir -p wp-content/uploads/cache/blade-cache"
+            "mkdir -p wp-content/uploads/cache/blade-cache",
+            "@php post-install.php"
         ]
     }
 }

--- a/post-install.php
+++ b/post-install.php
@@ -1,0 +1,9 @@
+<?php
+    $muPluginsDir = __DIR__ . '/wp-content/mu-plugins/';
+    $moveTo = $muPluginsDir . 'must_use_loader.php';
+    $muLoaderPath = $muPluginsDir.'must-use-loader/must_use_loader.php';
+    
+    if(file_exists($muLoaderPath)) {
+        rename($muLoaderPath, $moveTo);
+    }
+


### PR DESCRIPTION
Add a script to move must_use_loader.php from its subdir in mu-plugins
to the root of mu-plugins post install.